### PR TITLE
fix(api): wrap /eth/v1/beacon/blobs response in a data object

### DIFF
--- a/api/service/api.go
+++ b/api/service/api.go
@@ -316,6 +316,15 @@ func sidecarsToBlobs(sidecars []*deneb.BlobSidecar) v1.Blobs {
 	return blobs
 }
 
+// BlobsResponse is the JSON response body for the /eth/v1/beacon/blobs/{id}
+// endpoint. The blobs are wrapped in a top-level "data" field to match the
+// beacon-API spec (and the /eth/v1/beacon/blob_sidecars/ response). Without the
+// wrapper the endpoint emits a bare JSON array, which consumers such as op-node
+// cannot decode (they expect an object with a "data" field).
+type BlobsResponse struct {
+	Data v1.Blobs `json:"data"`
+}
+
 // blobsHandler implements the /eth/v1/beacon/blobs/{id} endpoint, using the underlying DataStoreReader
 // to fetch blobs instead of the beacon node. This endpoint serves blobs without KZG proofs.
 // Filtering by versioned_hashes query parameter is supported (per EIP-4844).
@@ -369,7 +378,7 @@ func (a *API) blobsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		w.Header().Set("Content-Type", jsonAcceptType)
-		err := json.NewEncoder(w).Encode(blobs)
+		err := json.NewEncoder(w).Encode(BlobsResponse{Data: blobs})
 		if err != nil {
 			a.logger.Error("unable to encode blobs to JSON", "err", err)
 			errServerError.write(w)

--- a/api/service/api_test.go
+++ b/api/service/api_test.go
@@ -394,9 +394,17 @@ func TestBlobsHandlerJSON(t *testing.T) {
 	require.Equal(t, 200, response.Code)
 	require.Equal(t, "application/json", response.Header().Get("Content-Type"))
 
-	var blobs v1.Blobs
-	err = json.Unmarshal(response.Body.Bytes(), &blobs)
+	// Regression guard: the response must be a JSON object with a top-level
+	// "data" field (per the beacon-API spec), not a bare JSON array. Consumers
+	// such as op-node decode into an object and fail on a bare array.
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &raw), "blobs response must be a JSON object")
+	require.Contains(t, raw, "data")
+
+	var resp BlobsResponse
+	err = json.Unmarshal(response.Body.Bytes(), &resp)
 	require.NoError(t, err)
+	blobs := resp.Data
 	require.Equal(t, len(testBlobs), len(blobs))
 
 	// Verify blob data matches
@@ -474,10 +482,10 @@ func TestBlobsHandlerWithVersionedHashes(t *testing.T) {
 
 	require.Equal(t, 200, response.Code)
 
-	var blobs v1.Blobs
-	err = json.Unmarshal(response.Body.Bytes(), &blobs)
+	var resp BlobsResponse
+	err = json.Unmarshal(response.Body.Bytes(), &resp)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(blobs))
+	require.Equal(t, 2, len(resp.Data))
 }
 
 func TestBlobsHandlerNotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

`GET /eth/v1/beacon/blobs/{block_id}` returns a **bare JSON array** of blobs instead of an object with a top-level `data` field. This is inconsistent with the beacon-API spec and with this service's own `/eth/v1/beacon/blob_sidecars/{id}` endpoint, and it breaks `op-node`'s blob-archiver fallback.

## Root cause

`blobsHandler` encoded the blobs slice directly:

```go
blobs := sidecarsToBlobs(filteredSidecars)   // v1.Blobs == []*deneb.Blob
json.NewEncoder(w).Encode(blobs)             // -> ["0x..","0x..",...]
```

`attestantio/go-eth2-client/api/v1.Blobs` is `type Blobs []*deneb.Blob` with no custom `MarshalJSON`, so it serializes as a bare array.

```jsonc
// real beacon node:        GET /eth/v1/beacon/blobs/<slot>
{"execution_optimistic":false,"finalized":true,"data":["0x..",...]}

// blob-archiver (before):  GET /eth/v1/beacon/blobs/<slot>
["0x..",...]
```

## Impact

`op-node` (recent Fusaka-era releases that migrated blob fetching to `/eth/v1/beacon/blobs/`) decodes this endpoint into a struct:

```go
type APIBeaconBlobsResponse struct {
    ...
    Data []*Blob `json:"data"`
}
```

When an L1 beacon has pruned data columns for an old slot (beyond the ~18-day blob-retention window), it returns `400`, and op-node falls back to the blob-archiver on the **same** `/eth/v1/beacon/blobs/` path. The bare-array response then fails to decode:

```
failed to fetch blobs: get blobs from beacon client: failed request with status 400: {...}
json: cannot unmarshal array into Go value of type eth.APIBeaconBlobsResponse
```

Net effect: op-node cannot backfill blobs from the archiver via `/blobs/` at all, and derivation stalls on any L1 range older than the beacon's blob retention — even though the archiver holds the data. The `/blob_sidecars/{id}` endpoint is unaffected (it already returns `{"data":[...]}`).

## Fix

Wrap the JSON response in a `data` object, consistent with this service's `/blob_sidecars/{id}` handler (`storage.BlobSidecars{Data ...}`) and the beacon-API spec:

```go
type BlobsResponse struct {
    Data v1.Blobs `json:"data"`
}
...
json.NewEncoder(w).Encode(BlobsResponse{Data: blobs})
```

SSZ output (a bare `List[Blob]`) is already spec-correct and is left unchanged.

## Prior art (Base trunk)

This fork tracks [`base/blob-archiver`](https://github.com/base/blob-archiver), whose trunk already wraps the `/blobs/` JSON response in a `data` object. This PR brings the `ethereum-optimism` fork to parity. The equivalent code on Base `master` (pinned to `df1f6e8`):

- `beaconBlobsResponse` struct with `Data v1.Blobs json:"data"` — https://github.com/base/blob-archiver/blob/df1f6e8cda1b9781c5890a0e8e92e485f6897706/api/service/api.go#L108-L112
- `newBeaconBlobsResponse` constructor — https://github.com/base/blob-archiver/blob/df1f6e8cda1b9781c5890a0e8e92e485f6897706/api/service/api.go#L386-L392
- the wrapped `Encode(...)` in `blobsHandler` — https://github.com/base/blob-archiver/blob/df1f6e8cda1b9781c5890a0e8e92e485f6897706/api/service/api.go#L447

Note: this is not a verbatim copy. Base's `blobsHandler` also emits `execution_optimistic`/`finalized` via `blockInfo.Metadata`, which this fork's handler does not plumb through (it reads from `storage.BlobData` and has no such metadata). This PR therefore adds only the `data` wrapper — the part required for beacon-API spec compliance and op-node decoding — matching this fork's existing `/blob_sidecars/` response shape.

## Testing

- `go build ./...`, `go vet ./api/service/`, `gofmt -l` — clean
- `go test ./api/...` — pass
- Updated `TestBlobsHandlerJSON` and `TestBlobsHandlerWithVersionedHashes` to decode the wrapped object, and added a regression guard asserting the response is a JSON object with a top-level `data` field (not a bare array). `TestBlobsHandlerSSZ` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
